### PR TITLE
Get last changes from upstream (remove bulk-order support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,7 @@ in `custom_strategy.py`.
 
 By default, the BitMEX API rate limit is 300 requests per 5 minute interval (avg 1/second).
 
-This bot uses the WebSocket and bulk order placement/amend to greatly reduce the number of calls sent to the BitMEX API.
-
-Most calls to the API consume one request, except:
-
-* Bulk order placement/amend: Consumes 0.1 requests, rounded up, per order. For example, placing 16 orders consumes
-  2 requests.
-* Bulk order cancel: Consumes 1 request no matter the size. Is not blocked by an exceeded ratelimit; cancels will
-  always succeed. This bot will always cancel all orders on an error or interrupt.
+This bot uses the WebSocket to greatly reduce the number of calls sent to the BitMEX API.
 
 If you are quoting multiple contracts and your ratelimit is becoming an obstacle, please
 [email support](mailto:support@bitmex.com) with details of your quoting. In the vast majority of cases,

--- a/market_maker/bitmex.py
+++ b/market_maker/bitmex.py
@@ -162,20 +162,20 @@ class BitMEX(object):
         return self._curl_bitmex(path=endpoint, postdict=postdict, verb="POST")
 
     @authentication_required
-    def amend_bulk_orders(self, orders):
+    def amend_orders(self, orders):
         """Amend multiple orders."""
-        # Note rethrow; if this fails, we want to catch it and re-tick
-        return self._curl_bitmex(path='order/bulk', postdict={'orders': orders}, verb='PUT', rethrow_errors=True)
+        for order in orders:
+            self._curl_bitmex(path='order', postdict=order, verb='PUT', rethrow_errors=True)
 
     @authentication_required
-    def create_bulk_orders(self, orders):
+    def create_orders(self, orders):
         """Create multiple orders."""
         for order in orders:
             order['clOrdID'] = self.orderIDPrefix + base64.b64encode(uuid.uuid4().bytes).decode('utf8').rstrip('=\n')
             order['symbol'] = self.symbol
             if self.postOnly:
                 order['execInst'] = 'ParticipateDoNotInitiate'
-        return self._curl_bitmex(path='order/bulk', postdict={'orders': orders}, verb='POST')
+            self._curl_bitmex(path='order', postdict=order, verb='POST',  rethrow_errors=True)
 
     @authentication_required
     def open_orders(self):

--- a/market_maker/market_maker.py
+++ b/market_maker/market_maker.py
@@ -182,17 +182,17 @@ class ExchangeInterface:
         if instrument['midPrice'] is None:
             raise errors.MarketEmptyError("Orderbook is empty, cannot quote")
 
-    def amend_bulk_orders(self, orders):
+    def amend_orders(self, orders):
         if self.dry_run:
             return orders
-        return self.bitmex.amend_bulk_orders(orders)
+        return self.bitmex.amend_orders(orders)
 
-    def create_bulk_orders(self, orders):
+    def create_orders(self, orders):
         if self.dry_run:
             return orders
-        return self.bitmex.create_bulk_orders(orders)
+        return self.bitmex.create_orders(orders)
 
-    def cancel_bulk_orders(self, orders):
+    def cancel_orders(self, orders):
         if self.dry_run:
             return orders
         return self.bitmex.cancel([order['orderID'] for order in orders])
@@ -393,7 +393,7 @@ class OrderManager:
             # made it not amendable.
             # If that happens, we need to catch it and re-tick.
             try:
-                self.exchange.amend_bulk_orders(to_amend)
+                self.exchange.amend_orders(to_amend)
             except requests.exceptions.HTTPError as e:
                 errorObj = e.response.json()
                 if errorObj['error']['message'] == 'Invalid ordStatus':
@@ -408,14 +408,14 @@ class OrderManager:
             logger.info("Creating %d orders:" % (len(to_create)))
             for order in reversed(to_create):
                 logger.info("%4s %d @ %.*f" % (order['side'], order['orderQty'], tickLog, order['price']))
-            self.exchange.create_bulk_orders(to_create)
+            self.exchange.create_orders(to_create)
 
         # Could happen if we exceed a delta limit
         if len(to_cancel) > 0:
             logger.info("Canceling %d orders:" % (len(to_cancel)))
             for order in reversed(to_cancel):
                 logger.info("%4s %d @ %.*f" % (order['side'], order['leavesQty'], tickLog, order['price']))
-            self.exchange.cancel_bulk_orders(to_cancel)
+            self.exchange.cancel_orders(to_cancel)
 
     ###
     # Position Limits


### PR DESCRIPTION
That's why I was having 404 since this night:

```
18-11-2021 11:13:18 - INFO - market_maker - Creating 1 orders:
18-11-2021 11:13:18 - INFO - market_maker -  Buy 100 @ 58965.0
18-11-2021 11:13:18 - ERROR - bitmex - Unable to contact the BitMEX API (404). Request: https://testnet.bitmex.com/api/v1/order/bulk 
 {"orders": [{"price": 58965.0, "orderQty": 100, "side": "Buy", "clOrdID": "mm_bitmex_d+KUPhatRZC54ekFIlMPog", "symbol": "XBTUSD"}]}
18-11-2021 11:13:18 - INFO - market_maker - Shutting down. All open orders will be cancelled.
18-11-2021 11:13:18 - INFO - market_maker - Resetting current position. Canceling all existing orders.
```